### PR TITLE
long() was removed in Python 3

### DIFF
--- a/gym/gym/utils/seeding.py
+++ b/gym/gym/utils/seeding.py
@@ -3,13 +3,12 @@ import numpy as np
 import os
 import random as _random
 import struct
-import sys
 
 from gym import error
 
-if sys.version_info < (3,):
+try:
     integer_types = (int, long)
-else:
+except NameError:
     integer_types = (int,)
 
 # Fortunately not needed right now!


### PR DESCRIPTION
Follows the Python porting best practice [use feature detection instead of version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).

flake8 testing of https://github.com/openai/mlsh on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./gym/gym/utils/seeding.py:11:27: F821 undefined name 'long'
    integer_types = (int, long)
                          ^
```