### PR TITLE
Typo: Missing comma (,) causes a Python syntax error

### DIFF
--- a/rl-algs/setup.py
+++ b/rl-algs/setup.py
@@ -6,7 +6,7 @@ setup(name='rl-algs',
           'scipy',
           'tqdm',
           'joblib',
-      ]
+      ],
       description="OpenAI baselines: high quality implementations of reinforcement learning algorithms",
       author="OpenAI",
 )


### PR DESCRIPTION
flake8 testing of https://github.com/openai/mlsh on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./rl-algs/setup.py:10:17: E999 SyntaxError: invalid syntax
      description="OpenAI baselines: high quality implementations of reinforcement learning algorithms",
                ^
1     E999 SyntaxError: invalid syntax
```